### PR TITLE
Fix Frontend Docker Container build with pnpm 10+

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@ RUN corepack enable
 
 WORKDIR /app-frontend
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: false
+  es5-ext: false


### PR DESCRIPTION
## Problem

I tried running the provided docker compose file. The frontend container fails at build. The error log looks as follows:

```
19.39 devDependencies:
19.39 + @biomejs/biome 2.4.0
19.39 + @types/node 20.19.25
19.39 + @types/react 18.3.26
19.39 + @types/react-dom 18.3.7
19.39 + @types/react-plotly.js 2.6.3
19.39 + @types/react-window 1.8.8
19.39 + @vitejs/plugin-react 4.7.0
19.39 + tailwindcss 4.1.17
19.39 + typescript 5.9.3
19.39 + vite 5.4.21
19.39
19.69 [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: es5-ext@0.10.64, esbuild@0.21.5
19.69
19.69 Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
------
Dockerfile:10

--------------------

   8 |

   9 |     COPY package.json pnpm-lock.yaml ./

  10 | >>> RUN pnpm install --frozen-lockfile

  11 |

  12 |     COPY . .

--------------------

target ocpq-frontend: failed to solve: process "/bin/sh -c pnpm install --frozen-lockfile" did not complete successfully: exit code: 1
```

## Root Cause

As a supply-chain hardening measure, since v11 pnpm requires explicit decision on all lifecycle scripts that are run as part of the installation. In this case, two packages -  es5-ext@0.10.64 and esbuild@0.21.5 - want to run some sort of postinstall script.

## Fix

Both postinstall scripts are not needed for the container to build successfully. The es5-ext script only checks the locale of the user running the script and shows a support message for Ukraine if the user locale is set to Russia. The esbuild script is a bit more complicated but from my understanding it only performs some optimization that should not be relevant for this project.

Both scripts are marked as false in the provided `pnpm-workspace.yaml` file.

## Reproduce and verify

To reproduce the bug, checkout the main branch and try to run

```
docker compose up -- build
```

The frontend container should fail at build. Afterwards, checkout this branch and run the build command again. The build should finish without any issues.